### PR TITLE
Warn then ignore cases of no output

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,6 +165,13 @@ var HTMLReporter = function(baseReporterDecorator, config, emitter, logger, help
       helper.normalizeWinPath(outputFile);
 
       helper.mkdirIfNotExists(path.dirname(outputFile), function() {
+        if(!htmlToOutput) {
+          log.warn('Cannot write HTML report\n\t No output!');
+          if (!--pendingFileWritings) {
+            fileWritingFinished();
+          }
+          return;
+        }
         fs.writeFile(outputFile, htmlToOutput.end({pretty: true}), function(err) {
           if (err) {
             log.warn('Cannot write HTML report\n\t' + err.message);


### PR DESCRIPTION
This change allows for no output to be warned and ignored. Without this, this plugin never exits as `fileWritingFinished()` is never called to due an exception being throwing calling `htmlToOutput.end`.